### PR TITLE
Backfill missing lab metadata (5 files)

### DIFF
--- a/Instructions/Labs/LP1 Lab - Bank foreign currency revaluation.md
+++ b/Instructions/Labs/LP1 Lab - Bank foreign currency revaluation.md
@@ -1,7 +1,14 @@
 ---
 lab:
-    title: 'Lab 1: Bank foreign currency revaluation'
-    module: 'Learning Path 01: Set up and configure financial management; work with General Ledger'
+  title: 'Lab 1: Bank foreign currency revaluation'
+  module: 'Learning Path 01: Set up and configure financial management; work with
+    General Ledger'
+  description: '**MB-310: Microsoft Dynamics 365 Financial Consultant**'
+  duration: 5 minutes
+  level: 100
+  islab: true
+  primarytopics:
+  - Dynamics 365
 ---
 
 **MB-310: Microsoft Dynamics 365 Financial Consultant**

--- a/Instructions/Labs/LP2 Lab - Calculate risk scores.md
+++ b/Instructions/Labs/LP2 Lab - Calculate risk scores.md
@@ -1,7 +1,13 @@
 ---
 lab:
-    title: 'Lab 2: Calculate risk scores'
-    module: 'Learning Path 02: Configure credit and collections'
+  title: 'Lab 2: Calculate risk scores'
+  module: 'Learning Path 02: Configure credit and collections'
+  description: '**MB-310: Microsoft Dynamics 365 Financial Consultant**'
+  duration: 5 minutes
+  level: 100
+  islab: true
+  primarytopics:
+  - Dynamics 365
 ---
 
 **MB-310: Microsoft Dynamics 365 Financial Consultant**

--- a/Instructions/Labs/LP3 Lab - Breakdown of voucher.md
+++ b/Instructions/Labs/LP3 Lab - Breakdown of voucher.md
@@ -1,7 +1,13 @@
 ---
 lab:
-    title: 'Lab 3: Breakdown of voucher'
-    module: 'Learning Path 03: Perform accounts payable daily procedures'
+  title: 'Lab 3: Breakdown of voucher'
+  module: 'Learning Path 03: Perform accounts payable daily procedures'
+  description: '**MB-310: Microsoft Dynamics 365 Financial Consultant**'
+  duration: 5 minutes
+  level: 100
+  islab: true
+  primarytopics:
+  - Dynamics 365
 ---
 
 **MB-310: Microsoft Dynamics 365 Financial Consultant**

--- a/Instructions/Labs/LP4 Lab - Budget planning.md
+++ b/Instructions/Labs/LP4 Lab - Budget planning.md
@@ -1,7 +1,13 @@
 ---
 lab:
-    title: 'Lab 4: Budget planning'
-    module: 'Learning Path 04: Configure and use budget planning'
+  title: 'Lab 4: Budget planning'
+  module: 'Learning Path 04: Configure and use budget planning'
+  description: '**MB-310: Microsoft Dynamics 365 Financial Consultant**'
+  duration: 5 minutes
+  level: 100
+  islab: true
+  primarytopics:
+  - Dynamics 365
 ---
 
 **MB-310: Microsoft Dynamics 365 Financial Consultant**

--- a/Instructions/Labs/LP5 Lab - Sell and purchase a fixed asset.md
+++ b/Instructions/Labs/LP5 Lab - Sell and purchase a fixed asset.md
@@ -1,7 +1,13 @@
 ---
 lab:
-    title: 'Lab 5: Sell and purchase a fixed asset'
-    module: 'Learning Path 05: Manage fixed assets'
+  title: 'Lab 5: Sell and purchase a fixed asset'
+  module: 'Learning Path 05: Manage fixed assets'
+  description: '**MB-310: Microsoft Dynamics 365 Financial Consultant**'
+  duration: 5 minutes
+  level: 100
+  islab: true
+  primarytopics:
+  - Dynamics 365
 ---
 
 **MB-310: Microsoft Dynamics 365 Financial Consultant**


### PR DESCRIPTION
This PR backfills missing lab metadata in markdown files.

Rules used:
- Add-only (does not overwrite existing metadata keys)
- Keys: lab.title, lab.description, lab.duration, lab.level, lab.islab
- Optional casing normalization to lowercase when enabled

Files changed: 5

- `Instructions/Labs/LP1 Lab - Bank foreign currency revaluation.md` (description,duration,level,islab,primarytopics)
- `Instructions/Labs/LP2 Lab - Calculate risk scores.md` (description,duration,level,islab,primarytopics)
- `Instructions/Labs/LP3 Lab - Breakdown of voucher.md` (description,duration,level,islab,primarytopics)
- `Instructions/Labs/LP4 Lab - Budget planning.md` (description,duration,level,islab,primarytopics)
- `Instructions/Labs/LP5 Lab - Sell and purchase a fixed asset.md` (description,duration,level,islab,primarytopics)
