### PR TITLE
Backfill missing lab metadata (5 files)

### DIFF
--- a/Instructions/Labs/LP1 Lab - Bank foreign currency revaluation.md
+++ b/Instructions/Labs/LP1 Lab - Bank foreign currency revaluation.md
@@ -1,7 +1,11 @@
 ---
 lab:
-    title: 'Lab 1: Bank foreign currency revaluation'
-    module: 'Learning Path 01: Set up and configure financial management; work with General Ledger'
+  title: 'Lab 1: Bank foreign currency revaluation'
+  module: 'Learning Path 01: Set up and configure financial management; work with General Ledger'
+  description: During this lab, you will first enter a transaction in a bank journal that can be revalued. The second step is to prepare foreign currency revaluation. After you configure the foreign currency revaluation, you run the process and then review the results.
+  duration: 5 minutes
+  level: 100
+  islab: true
 ---
 
 **MB-310: Microsoft Dynamics 365 Financial Consultant**

--- a/Instructions/Labs/LP1 Lab - Bank foreign currency revaluation.md
+++ b/Instructions/Labs/LP1 Lab - Bank foreign currency revaluation.md
@@ -3,8 +3,8 @@ lab:
   title: 'Lab 1: Bank foreign currency revaluation'
   module: 'Learning Path 01: Set up and configure financial management; work with General Ledger'
   description: During this lab, you will first enter a transaction in a bank journal that can be revalued. The second step is to prepare foreign currency revaluation. After you configure the foreign currency revaluation, you run the process and then review the results.
-  duration: 5 minutes
-  level: 100
+  duration: 10 minutes
+  level: 300
   islab: true
 ---
 
@@ -231,3 +231,4 @@ in USMF.
 1.  Close the form.
 
 By completing this lab, you validated how exchange rate changes affect foreign currency bank accounts by executing a revaluation and reviewing the resulting gain or loss in Dynamics 365 Finance.
+

--- a/Instructions/Labs/LP2 Lab - Calculate risk scores.md
+++ b/Instructions/Labs/LP2 Lab - Calculate risk scores.md
@@ -1,7 +1,11 @@
 ---
 lab:
-    title: 'Lab 2: Calculate risk scores'
-    module: 'Learning Path 02: Configure credit and collections'
+  title: 'Lab 2: Calculate risk scores'
+  module: 'Learning Path 02: Configure credit and collections'
+  description: During this lab, you will configure a scoring group, add the new group to a customer, and calculate the risk group classification to determine how risky the customer is.
+  duration: 5 minutes
+  level: 100
+  islab: true
 ---
 
 **MB-310: Microsoft Dynamics 365 Financial Consultant**

--- a/Instructions/Labs/LP2 Lab - Calculate risk scores.md
+++ b/Instructions/Labs/LP2 Lab - Calculate risk scores.md
@@ -3,8 +3,8 @@ lab:
   title: 'Lab 2: Calculate risk scores'
   module: 'Learning Path 02: Configure credit and collections'
   description: During this lab, you will configure a scoring group, add the new group to a customer, and calculate the risk group classification to determine how risky the customer is.
-  duration: 5 minutes
-  level: 100
+  duration: 20 minutes
+  level: 300
   islab: true
 ---
 
@@ -179,4 +179,5 @@ group that must be used to calculate the customer’s risk.
 ![The Vendor page is open and on the Credit management tab, Risk score is selected.](images/LP216.png)
 
 1.  Close the form.
+
 

--- a/Instructions/Labs/LP3 Lab - Breakdown of voucher.md
+++ b/Instructions/Labs/LP3 Lab - Breakdown of voucher.md
@@ -3,8 +3,8 @@ lab:
   title: 'Lab 3: Breakdown of voucher'
   module: 'Learning Path 03: Perform accounts payable daily procedures'
   description: Use the USMF company for the exercises in this lab.
-  duration: 5 minutes
-  level: 100
+  duration: 15 minutes
+  level: 300
   islab: true
 ---
 
@@ -134,4 +134,5 @@ to the breakdown of the voucher.
 ![The Vendor invoice journal page is open. The message Operation completed appears in the message bar.](images/LP318.png)
 
 By doing this lab, you ensured accurate tax calculation and compliant financial posting by breaking down a vendor invoice into multiple voucher lines with correct tax rates in Dynamics 365 Finance.
+
 

--- a/Instructions/Labs/LP3 Lab - Breakdown of voucher.md
+++ b/Instructions/Labs/LP3 Lab - Breakdown of voucher.md
@@ -1,7 +1,11 @@
 ---
 lab:
-    title: 'Lab 3: Breakdown of voucher'
-    module: 'Learning Path 03: Perform accounts payable daily procedures'
+  title: 'Lab 3: Breakdown of voucher'
+  module: 'Learning Path 03: Perform accounts payable daily procedures'
+  description: Use the USMF company for the exercises in this lab.
+  duration: 5 minutes
+  level: 100
+  islab: true
 ---
 
 **MB-310: Microsoft Dynamics 365 Financial Consultant**

--- a/Instructions/Labs/LP4 Lab - Budget planning.md
+++ b/Instructions/Labs/LP4 Lab - Budget planning.md
@@ -3,8 +3,8 @@ lab:
   title: 'Lab 4: Budget planning'
   module: 'Learning Path 04: Configure and use budget planning'
   description: Microsoft Dynamics 365 Finance can help you create different budget scenarios based on various assumptions. For example, you could create a base case scenario, an optimistic scenario, and a pessimistic scenario.
-  duration: 5 minutes
-  level: 100
+  duration: 30 minutes
+  level: 300
   islab: true
   primarytopics:
     - Dynamics 365
@@ -468,4 +468,5 @@ from the General ledger.
 1.  Select **Submit**.
 
 >   The finance department will need to review and approve the budget plan.
+
 

--- a/Instructions/Labs/LP4 Lab - Budget planning.md
+++ b/Instructions/Labs/LP4 Lab - Budget planning.md
@@ -1,7 +1,13 @@
 ---
 lab:
-    title: 'Lab 4: Budget planning'
-    module: 'Learning Path 04: Configure and use budget planning'
+  title: 'Lab 4: Budget planning'
+  module: 'Learning Path 04: Configure and use budget planning'
+  description: Microsoft Dynamics 365 Finance can help you create different budget scenarios based on various assumptions. For example, you could create a base case scenario, an optimistic scenario, and a pessimistic scenario.
+  duration: 5 minutes
+  level: 100
+  islab: true
+  primarytopics:
+    - Dynamics 365
 ---
 
 **MB-310: Microsoft Dynamics 365 Financial Consultant**

--- a/Instructions/Labs/LP5 Lab - Sell and purchase a fixed asset.md
+++ b/Instructions/Labs/LP5 Lab - Sell and purchase a fixed asset.md
@@ -3,8 +3,8 @@ lab:
   title: 'Lab 5: Sell and purchase a fixed asset'
   module: 'Learning Path 05: Manage fixed assets'
   description: During this lab you will sell a fixed asset and purchase a fixed asset.
-  duration: 5 minutes
-  level: 100
+  duration: 15 minutes
+  level: 300
   islab: true
 ---
 
@@ -205,4 +205,5 @@ The match status changes to **Passed**.
 ![Fixed assets page with the acquisition amount for COMP-000008 posted.](images/LP523.png)
 
 Close the form. You’ve acquired and verified the asset.
+
 

--- a/Instructions/Labs/LP5 Lab - Sell and purchase a fixed asset.md
+++ b/Instructions/Labs/LP5 Lab - Sell and purchase a fixed asset.md
@@ -1,7 +1,11 @@
 ---
 lab:
-    title: 'Lab 5: Sell and purchase a fixed asset'
-    module: 'Learning Path 05: Manage fixed assets'
+  title: 'Lab 5: Sell and purchase a fixed asset'
+  module: 'Learning Path 05: Manage fixed assets'
+  description: During this lab you will sell a fixed asset and purchase a fixed asset.
+  duration: 5 minutes
+  level: 100
+  islab: true
 ---
 
 **MB-310: Microsoft Dynamics 365 Financial Consultant**


### PR DESCRIPTION
This PR backfills missing lab metadata in markdown files.

Rules used:
- Add-only (does not overwrite existing metadata keys)
- Keys: lab.title, lab.description, lab.duration, lab.level, lab.islab
- Optional casing normalization to lowercase when enabled

Files changed: 5

- `Instructions/Labs/LP1 Lab - Bank foreign currency revaluation.md` (description,duration,level,islab)
- `Instructions/Labs/LP2 Lab - Calculate risk scores.md` (description,duration,level,islab)
- `Instructions/Labs/LP3 Lab - Breakdown of voucher.md` (description,duration,level,islab)
- `Instructions/Labs/LP4 Lab - Budget planning.md` (description,duration,level,islab,primarytopics)
- `Instructions/Labs/LP5 Lab - Sell and purchase a fixed asset.md` (description,duration,level,islab)
